### PR TITLE
test: add storage package coverage

### DIFF
--- a/storage/duration_test.go
+++ b/storage/duration_test.go
@@ -1,0 +1,38 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestParseDuration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want time.Duration
+		err  error
+	}{
+		{name: "minutes", in: "15m", want: 15 * time.Minute},
+		{name: "hours", in: "2h", want: 2 * durHour},
+		{name: "days", in: "3d", want: 3 * durDay},
+		{name: "weeks", in: "4w", want: 4 * durWeek},
+		{name: "years", in: "5y", want: 5 * durYear},
+		{name: "invalid format", in: "abc", err: errInvalidDuration},
+		{name: "unknown unit", in: "30q", err: errInvalidUnit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDuration(tt.in)
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("parseDuration(%q) error = %v, want %v", tt.in, err, tt.err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseDuration(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/storage/serial_test.go
+++ b/storage/serial_test.go
@@ -1,0 +1,39 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAllocNextSerialStartsAtOneAndIncrements(t *testing.T) {
+	t.Parallel()
+
+	s := &Storage{}
+	dir := t.TempDir()
+
+	first, err := s.allocNextSerial(dir)
+	if err != nil {
+		t.Fatalf("allocNextSerial first call returned error: %v", err)
+	}
+	if first != 1 {
+		t.Fatalf("first serial = %d, want 1", first)
+	}
+
+	second, err := s.allocNextSerial(dir)
+	if err != nil {
+		t.Fatalf("allocNextSerial second call returned error: %v", err)
+	}
+	if second != 2 {
+		t.Fatalf("second serial = %d, want 2", second)
+	}
+
+	serialFile := filepath.Join(dir, filenameSerial)
+	contents, err := os.ReadFile(serialFile)
+	if err != nil {
+		t.Fatalf("read serial file: %v", err)
+	}
+	if string(contents) != "2" {
+		t.Fatalf("serial file = %q, want %q", contents, "2")
+	}
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,0 +1,111 @@
+package storage
+
+import (
+	"bytes"
+	"encoding/pem"
+	"errors"
+	"testing"
+)
+
+func TestStorageCreatesPersistsExportsAndDeletesCertificates(t *testing.T) {
+	dataDir := t.TempDir()
+	s := newTestStorage(t, dataDir)
+
+	rootID, err := s.CreateCertificate("", &CreateCertificateParams{
+		CommonName:    "Root CA",
+		Organization:  "Example Org",
+		Validity:      "1h",
+		CanSign:       true,
+		AllowChaining: true,
+	})
+	if err != nil {
+		t.Fatalf("create root certificate: %v", err)
+	}
+
+	roots := s.GetRootCertificates()
+	if len(roots) != 1 {
+		t.Fatalf("root certificate count = %d, want 1", len(roots))
+	}
+	if roots[0].ID != rootID {
+		t.Fatalf("root ID = %q, want %q", roots[0].ID, rootID)
+	}
+
+	root, err := s.GetCertificate(rootID)
+	if err != nil {
+		t.Fatalf("get root certificate: %v", err)
+	}
+	if root.X509.Subject.CommonName != "Root CA" {
+		t.Fatalf("root common name = %q, want %q", root.X509.Subject.CommonName, "Root CA")
+	}
+	if !root.CanSign() {
+		t.Fatal("root certificate should be able to sign")
+	}
+
+	childID, err := s.CreateCertificate(rootID, &CreateCertificateParams{
+		CommonName: "service.example.test",
+		Validity:   "30m",
+		ServerAuth: true,
+		SANs:       "service.example.test 127.0.0.1",
+	})
+	if err != nil {
+		t.Fatalf("create child certificate: %v", err)
+	}
+
+	child, err := s.GetCertificate(childID)
+	if err != nil {
+		t.Fatalf("get child certificate: %v", err)
+	}
+	if len(child.Parents) != 1 || child.Parents[0].ID != rootID {
+		t.Fatalf("child parents = %#v, want root %q", child.Parents, rootID)
+	}
+	if child.CanSign() {
+		t.Fatal("leaf certificate should not be able to sign")
+	}
+	if err := s.ValidateCertificate(childID); err != nil {
+		t.Fatalf("validate child certificate: %v", err)
+	}
+
+	pemBytes, err := s.ExportCertificatePEM(childID)
+	if err != nil {
+		t.Fatalf("export child certificate PEM: %v", err)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != typeCertificate {
+		t.Fatalf("exported PEM block = %#v, want certificate block", block)
+	}
+
+	publicKey, err := s.ExportPublicKeyPEM(childID)
+	if err != nil {
+		t.Fatalf("export child public key: %v", err)
+	}
+	if !bytes.Contains(publicKey, []byte("BEGIN PUBLIC KEY")) {
+		t.Fatalf("public key export does not contain a PEM public key: %q", publicKey)
+	}
+
+	reloaded := newTestStorage(t, dataDir)
+	if _, err := reloaded.GetCertificate(childID); err != nil {
+		t.Fatalf("get child certificate after reload: %v", err)
+	}
+
+	if err := reloaded.DeleteCertificate(rootID); err != nil {
+		t.Fatalf("delete root certificate: %v", err)
+	}
+	if _, err := reloaded.GetCertificate(rootID); !errors.Is(err, errCertDoesNotExist) {
+		t.Fatalf("get deleted root error = %v, want %v", err, errCertDoesNotExist)
+	}
+	if _, err := reloaded.GetCertificate(childID); !errors.Is(err, errCertDoesNotExist) {
+		t.Fatalf("get deleted child error = %v, want %v", err, errCertDoesNotExist)
+	}
+}
+
+func newTestStorage(t *testing.T, dataDir string) *Storage {
+	t.Helper()
+
+	s, err := New(&Config{
+		DataDir: dataDir,
+	})
+	if err != nil {
+		t.Fatalf("new storage: %v", err)
+	}
+	return s
+}


### PR DESCRIPTION
## Summary
- add table tests for storage duration parsing
- cover serial allocation persistence
- exercise the Storage create, reload, export, validate, and delete flow with temporary on-disk data

Closes #18

## Tests
- `go test ./storage`
- `go test ./storage ./server`
- `git diff --check`

Note: `go test ./...` currently fails on macOS before reaching these tests because `github.com/nathan-osman/gosvc` does not provide `newPlatform` for this platform.